### PR TITLE
Fixed CRLF in init.d script

### DIFF
--- a/server/lib/service/systemv/index.js
+++ b/server/lib/service/systemv/index.js
@@ -38,6 +38,8 @@ Service.prototype.install = function(){
         if (err){
             throw new Error(err);
         }
+
+        data = data.replace(new RegExp('\x0d', 'g'), '');
         fs.writeFile(initdScript, data, {mode: 0755}, function(err){
             if (err) {
                 throw new Error(err);


### PR DESCRIPTION
ejs insert carriage return in method renderFile
init script get error 

``` sh
bash: ./nodehosting: /bin/sh^M: bad interpreter: No such file or directory
```

node.js 4.1.1, ejs 2.3.4
